### PR TITLE
Alpha-13-pixel-stuff

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -3,7 +3,6 @@ $(call inherit-product-if-exists, vendor/extra/product.mk)
 $(call inherit-product-if-exists, vendor/lineage/config/crdroid.mk)
 $(call inherit-product-if-exists, vendor/lineage/config/alpha.mk)
 $(call inherit-product-if-exists, vendor/addons/config.mk)
-$(call inherit-product-if-exists, external/faceunlock/config.mk)
 
 PRODUCT_BUILD_PROP_OVERRIDES += BUILD_UTC_DATE=0
 
@@ -143,6 +142,18 @@ PRODUCT_ARTIFACT_PATH_REQUIREMENT_ALLOWED_LIST += \
     system/bin/mount.ntfs \
     system/%/libfuse-lite.so \
     system/%/libntfs-3g.so
+
+# Faceunlock
+TARGET_FACE_UNLOCK_SUPPORTED ?= true
+ifeq ($(TARGET_FACE_UNLOCK_SUPPORTED),true)
+$(call inherit-product-if-exists, external/faceunlock/config.mk)
+PRODUCT_PACKAGES += \
+    FaceUnlockService
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+    ro.face_unlock_service.enabled=$(TARGET_FACE_UNLOCK_SUPPORTED)
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.biometrics.face.xml:$(TARGET_COPY_OUT_SYSTEM)/etc/permissions/android.hardware.biometrics.face.xml
+endif
 
 # Openssh
 PRODUCT_PACKAGES += \

--- a/overlay/common/lineage-sdk/lineage/res/res/values/config.xml
+++ b/overlay/common/lineage-sdk/lineage/res/res/values/config.xml
@@ -21,12 +21,6 @@
         <item>com.android.vending/com.google.android.finsky.systemupdateactivity.SettingsSecurityEntryPoint</item>
         <item>com.android.vending/com.google.android.finsky.systemupdateactivity.SystemUpdateActivity</item>
         <item>com.android.vending/com.google.android.finsky.systemupdate.SystemUpdateSettingsContentProvider</item>
-        <item>com.google.android.as/com.google.android.apps.miphone.aiai.adaptiveaudio.settings.ui.AdaptiveAudioSettingsActivity</item>
-        <item>com.google.android.as/com.google.intelligence.sense.ambientmusic.AmbientMusicNotificationsSettingsActivity</item>
-        <item>com.google.android.as/com.google.intelligence.sense.ambientmusic.AmbientMusicSettingsActivity</item>
-        <item>com.google.android.as/com.google.intelligence.sense.ambientmusic.AmbientMusicSetupWizardActivity</item>
-        <item>com.google.android.as/com.google.intelligence.sense.ambientmusic.history.HistoryActivity</item>
-        <item>com.google.android.as/com.google.intelligence.sense.ambientmusic.history.HistoryContentProvider</item>
         <item>com.google.android.gms/com.google.android.gms.update.OtaSuggestionSummaryProvider</item>
         <item>com.google.android.gms/com.google.android.gms.update.phone.PopupDialog</item>
         <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateActivity</item>


### PR DESCRIPTION
* Some devices like pantah (Pixel 7/7 Pro) utilize
   
  a different implementation then what most devices
  use and prior to this change, the config.mk was
  still being inherited which in the Pixel 7s case
  breaks the function completely. With this change
  there is no functional different to the device
  tree. It will check if the if the build flag is
  not false then the code block is executed. If it
  finds the face unlock build flag empty set it to
  "true".

* lineage-sdk: enable Ambient Music component from ASI package

 Enables Now Playing option in Settings>Sound

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>