### PR TITLE
added module aapt_version_code_defaults

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -52,6 +52,26 @@ cc_library_headers {
 
 // Target platform agnostic config modules
 soong_config_module_type {
+    name: "aapt_version_code",
+    module_type: "java_defaults",
+    config_namespace: "lineageGlobalVars",
+    value_variables: ["aapt_version_code"],
+    properties: ["aaptflags"],
+}
+
+aapt_version_code {
+    name: "aapt_version_code_defaults",
+    soong_config_variables: {
+        aapt_version_code: {
+            aaptflags: [
+                "--version-code",
+                "%s",
+            ],
+        },
+    },
+}
+
+soong_config_module_type {
     name: "camera_needs_client_info_lib",
     module_type: "cc_defaults",
     config_namespace: "lineageGlobalVars",


### PR DESCRIPTION
"ApertureLensLauncher" depends on module "aapt_version_code_defaults"  getting error because this was not there