### PR TITLE
Include vendor/lineage-priv/keys/keys.mk for unofficial builds

### DIFF
--- a/config/version.mk
+++ b/config/version.mk
@@ -15,6 +15,9 @@ ifeq ($(filter-out OFFICIAL Official official,$(ALPHA_BUILD_TYPE)),)
     vendor/lineage/prebuilt/common/etc/init/init.lineage-updater.rc:$(TARGET_COPY_OUT_SYSTEM_EXT)/etc/init/init.lineage-updater.rc
 
   -include vendor/alpha/keys/keys.mk
+else
+  # Include keys.mk from the LineageOS location for unofficial builds
+  -include vendor/lineage-priv/keys/keys.mk
 endif
 
 # TARGET_BUILD_PACKAGE options:


### PR DESCRIPTION
to help signing unofficial builds.

Google's been cracking down on unsigned custom ROMs passing Play Integrity checks. To stay on the safe side, you'll now need to sign your ROM packages with release keys instead of test keys.

In commit 11e89e0c3a36 ("Sign official builds using Alpha private certificates and keys") the always include behavior was modified.

To help unofficial builders to sign their ROMs, include again the keys.mk from the LineageOS location.

There are a lot of how-to about signing your unofficial build, the crDroid one [1] [2] is the easiest, the LineageOS one [3] is the most detailed and it signs APEXes too, but one could find it too manual.
And there is ltsVixano's template repository for this topic. [4]

[1]: https://crdroid.net/blog/2024-06-01-sign-your-crDroid-builds-and-keep-play-integrity-happy
[2]: https://github.com/306bobby-android/crDroid-build-signed-script
[3]: https://wiki.lineageos.org/signing_builds
[4]: https://github.com/ItsVixano/android_vendor_lineage-priv_keys

Fixes: 11e89e0c3a36 ("Sign official builds using Alpha private certificates and keys")